### PR TITLE
Remove stray brace from midas bot

### DIFF
--- a/bot/midas.js
+++ b/bot/midas.js
@@ -331,4 +331,5 @@ async function main() {
   
 
 
-main().catch((e) => { console.error(e); process.exit(1); });  } 
+main().catch((e) => { console.error(e); process.exit(1); });
+ 


### PR DESCRIPTION
## Summary
- fix malformed closing brace after `main().catch` in `bot/midas.js`
- ensure file ends with a newline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6a5e58d6c8332aa410beb2e37aac0